### PR TITLE
EuiSpacer

### DIFF
--- a/addon/components/eui-spacer/index.hbs
+++ b/addon/components/eui-spacer/index.hbs
@@ -1,7 +1,7 @@
 <div class=
   {{if @size
     (concat "euiSpacer--" @size)
-    "euiSpacer--m"
+    "euiSpacer--l"
   }}
   aria-label={{@ariaLabel}}
   data-test-subj={{@dataTestSubj}}

--- a/addon/components/eui-spacer/index.hbs
+++ b/addon/components/eui-spacer/index.hbs
@@ -1,9 +1,1 @@
-<div class=
-  {{if @size
-    (concat "euiSpacer--" @size)
-    "euiSpacer--l"
-  }}
-  aria-label={{@ariaLabel}}
-  data-test-subj={{@dataTestSubj}}
-  ...attributes
-/>
+<div class={{class-names "EuiSpacer" size=(arg-or-default @size "l")}} ...attributes />

--- a/addon/components/eui-spacer/index.hbs
+++ b/addon/components/eui-spacer/index.hbs
@@ -1,0 +1,9 @@
+<div class=
+  {{if @size
+    (concat "euiSpacer--" @size)
+    "euiSpacer--m"
+  }}
+  aria-label={{@ariaLabel}}
+  data-test-subj={{@dataTestSubj}}
+  ...attributes
+/>

--- a/addon/utils/css-mappings/eui-spacer.ts
+++ b/addon/utils/css-mappings/eui-spacer.ts
@@ -1,0 +1,19 @@
+export const baseClass: string = 'euiSpacer';
+
+export const sizeMapping = {
+  xs: `${baseClass}--xs`,
+  s: `${baseClass}--s`,
+  m: `${baseClass}--m`,
+  l: `${baseClass}--l`,
+  xl: `${baseClass}--xl`,
+  xxl: `${baseClass}--xxl`
+};
+
+const mapping: ComponentMapping = {
+  base: baseClass,
+  properties: {
+    size: sizeMapping
+  }
+};
+
+export default mapping;

--- a/addon/utils/css-mappings/index.ts
+++ b/addon/utils/css-mappings/index.ts
@@ -1,7 +1,10 @@
 import EuiLoadingSpinner from './eui-loading-spinner';
+import EuiSpacer from './eui-spacer';
+
 
 const mapping: Mapping = {
-  EuiLoadingSpinner
+  EuiLoadingSpinner,
+  EuiSpacer
 }
 
 export default mapping;

--- a/app/components/eui-spacer/index.js
+++ b/app/components/eui-spacer/index.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-eui/components/eui-spacer';


### PR DESCRIPTION
## Description
Template only component for layout component EuiSpacer. 
A simple div with up to 6 different size classes:
`xs`, `s`, `m`, `l`, `xl`, `xxl`

> When a size prop is not provided, the component defaults to `@size="l"`

### Props
@ size                        - `xs`, `s`, `m`, `l` (default), `xl`, `xxl`

## Example
```hbs
<EuiSpacer 
  @size="xl"
  aria-label="eui-spacer-div"
  data-test-subj="eui-spacer-test-subj"
/>
```

## Screenshots
![Screen Shot 2020-10-05 at 11 15 21 AM](https://user-images.githubusercontent.com/17131846/95104945-1643cf00-06fc-11eb-9c6e-6d94a30958c0.png)
