### PR TITLE
Update EuiAccordion to use EuiIcon

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,15 +1,15 @@
 {
 	"parser": "typescript",
-	"printWidth": 80,
+	"printWidth": 100,
 	"semi": true,
 	"singleQuote": true,
 	"trailingComma": "es5",
 	"overrides": [
 		{
-		  "files": "*.hbs",
-		  "options": {
-			"singleQuote": false
-		  }
+			"files": "*.hbs",
+			"options": {
+				"singleQuote": false
+			}
 		}
-	  ]
-  }
+	]
+}

--- a/addon/components/eui-accordion/index.hbs
+++ b/addon/components/eui-accordion/index.hbs
@@ -21,22 +21,14 @@
             (if this.hasIconButton "euiAccordion__iconButton ")
           }}
         >
-          {{!-- <EuiIcon
-            class={{concat
+          <EuiIcon
+            class={{class-names "EuiIcon"
               "euiAccordion__icon"
-              (if this.isOpen " euiAccordion__icon-isOpen")
+              (if this.isOpen "euiAccordion__icon-isOpen")
             }}
             @type="arrowRight"
             @size="m"
-          /> --}}
-          <div
-            class={{concat
-              "euiAccordion__icon"
-              (if this.isOpen " euiAccordion__icon-isOpen")
-            }}
-          >
-            ▶️
-          </div>
+          />
         </span>
       {{/if}}
       <span
@@ -69,22 +61,14 @@
         }}
         {{on "click" this.onToggle}}
       >
-        {{!-- <EuiIcon
-          class={{concat
+        <EuiIcon
+          class={{class-names "EuiIcon"
             "euiAccordion__icon"
-            (if this.isOpen " euiAccordion__icon-isOpen")
+            (if this.isOpen "euiAccordion__icon-isOpen")
           }}
           @type="arrowRight"
           @size="m"
-        /> --}}
-        <div
-          class={{concat
-            "euiAccordion__icon"
-            (if this.isOpen " euiAccordion__icon-isOpen")
-          }}
-        >
-          ▶️
-        </div>
+        />
       </button>
     {{/if}}
   </div>


### PR DESCRIPTION
Use `EuiIcon` instead of placeholders on `EuiAccordion`.
Change `.prettierrc` `printWidth` to a more sensible length of 100.