### PR TITLE
EuiCallout

### DIFF
--- a/addon/components/eui-callout/index.hbs
+++ b/addon/components/eui-callout/index.hbs
@@ -1,0 +1,31 @@
+<div
+  class={{class-names
+    componentName="EuiCallout"
+    size=(arg-or-default @size "m")
+    color=(arg-or-default @color "primary")
+  }}
+  ...attributes
+>
+  {{#if @title}}
+    {{#let (element (arg-or-default @heading "span")) as |H|}}
+      <div class="euiCallOutHeader">
+        {{#if @iconType}}
+          <EuiIcon
+            class="euiCallOutHeader__icon"
+            @type={{@iconType}}
+            @size="m"
+            aria-hidden="true"
+          />
+        {{/if}}
+        <H class="euiCallOutHeader__title">
+          {{@title}}
+        </H>
+      </div>
+    {{/let}}
+  {{/if}}
+  {{#if hasBlock}}
+    <EuiText @size={{if (eq @size "s") "xs" "s"}}>
+      {{yield}}
+    </EuiText>
+  {{/if}}
+</div>

--- a/addon/utils/css-mappings/eui-callout.ts
+++ b/addon/utils/css-mappings/eui-callout.ts
@@ -1,0 +1,22 @@
+export const baseClass: string = 'euiCallOut';
+
+export const colorMapping = {
+  primary: `${baseClass}--primary`,
+  success: `${baseClass}--success`,
+  warning: `${baseClass}--warning`,
+  danger: `${baseClass}--danger`
+};
+
+export const sizeMapping = {
+  s: `${baseClass}--small`
+}
+
+const mapping: ComponentMapping = {
+  base: baseClass,
+  properties: {
+    color: colorMapping,
+    size: sizeMapping
+  }
+};
+
+export default mapping;

--- a/addon/utils/css-mappings/index.ts
+++ b/addon/utils/css-mappings/index.ts
@@ -10,6 +10,7 @@ import EuiTextColor from './eui-text-color';
 import EuiText from './eui-text';
 import EuiPanel from './eui-panel';
 import EuiPageContent from './eui-page-content';
+import EuiCallout from './eui-callout';
 
 const mapping: Mapping = {
   EuiAccordion,
@@ -22,7 +23,8 @@ const mapping: Mapping = {
   EuiTextColor,
   EuiText,
   EuiPanel,
-  EuiPageContent
+  EuiPageContent,
+  EuiCallout
 }
 
 export default mapping;

--- a/app/components/eui-callout/index.js
+++ b/app/components/eui-callout/index.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-eui/components/eui-callout';

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -16,5 +16,6 @@ Router.map(function() {
     this.route('title');
     this.route('image');
     this.route('overlay-mask');
+    this.route('callout');
   })
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -33,6 +33,9 @@
         Overlay Mask
       </LinkTo>
       <EuiSpacer />
+      <LinkTo @route="demo.callout">
+        Callout
+      </LinkTo>
     </EuiPanel>
   </EuiPageSideBar>
   <EuiPageBody @tag="div">

--- a/tests/dummy/app/templates/demo/callout.hbs
+++ b/tests/dummy/app/templates/demo/callout.hbs
@@ -1,0 +1,53 @@
+<EuiPageHeader>
+  <EuiPageHeaderSection>
+    <EuiTitle @size="l">
+      <h1>
+        Eui Callout
+      </h1>
+    </EuiTitle>
+  </EuiPageHeaderSection>
+</EuiPageHeader>
+<EuiPageContent>
+  <EuiPageContentBody>
+
+    <EuiText size="xs"><p>Default Small callout H3</p></EuiText>
+    <EuiCallout @iconType="searchProfilerApp" @title="Good status" @heading="h3" @color="primary" @size="s">
+      <p>
+        All systems check, you are good to go. Good luck!
+      </p>
+    </EuiCallout>
+    <EuiSpacer />
+
+    <EuiText size="xs"><p>Warning Medium callout H3</p></EuiText>
+    <EuiCallout @iconType="alert" @title="INCOMING!" @heading="h3" @color="warning">
+      <p>
+        You have an homing rocket coming your way! Take evasive action!
+      </p>
+    </EuiCallout>
+    <EuiSpacer />
+
+    <EuiText size="xs"><p>Danger Medium callout H1</p></EuiText>
+    <EuiCallout @iconType="wrench" @title="Watch out! Danger close!" @heading="h1" @color="danger" @size="m">
+      <p>
+        You have been hit! Seek the repair ship immediately!
+      </p>
+    </EuiCallout>
+    <EuiSpacer />
+
+    <EuiText size="xs"><p>Success Medium callout H3</p></EuiText>
+    <EuiCallout @iconType="bullseye" @title="Great, you're ready for deployment!" @heading="h3" @color="success" @size="m">
+      <p>
+        Your ship has been repaired, you are good to launch again. Next time evade those missiles!
+      </p>
+    </EuiCallout>
+    <EuiSpacer />
+
+    <EuiText size="xs"><p>Default Callout without block</p></EuiText>
+    <EuiCallout @iconType="grid" @title="This is a Callout without block!" @size="m" />
+    <EuiSpacer />
+
+    <EuiText size="xs"><p>Default Callout H3 without block or icon</p></EuiText>
+    <EuiCallout @title="This is a Callout without block or Icon!" @heading="h3"  @size="m" />
+
+  </EuiPageContentBody>
+</EuiPageContent>


### PR DESCRIPTION
## Description
`<EuiCallout />` component implemented. Fairly easy and straightforward to use.

## Usage
### Props
- `@title` - `string`: Title that goes atop the Callout alongside the optional `@iconType`.
- `@iconType` - `string`: Icon that applies to the EuiIcon, it's placed on the left of the title.
- `@color` - `string`: Accepts one of four options; `primary` (default), `warning`, `danger`, `success`. Determines the color of the entire Callout.
- `@size` - `string`: Accepts `"s"`, `"m"` (default). `"s"` option makes the general size smaller, including the text size of the block and tittle.
- `@heading` - `string`: Tag of the title (`"h1"`, `"h2"`, `"h3"`, `"h4"`, `"h5"`, `"h6"`). `span` is the default.

### Examples
```hbs
<EuiCallout 
  @iconType="searchProfilerApp"
  @title="Good status"
  @heading="h3"
  @color="primary"
  @size="s"
>
  <p>All systems check, you are good to go. Good luck!</p>
</EuiCallout>
```
![Screen Shot 2020-10-15 at 3 48 27 PM](https://user-images.githubusercontent.com/17131846/96184280-e071c800-0efd-11eb-9d25-930031aec121.png)

```hbs
<EuiCallout 
  @iconType="wrench"
  @title="Watch out! Danger close!"
  @heading="h3"
  @color="danger"
  @size="m"
>
  <p>You have been hit! Seek the repair ship immediately!</p>
</EuiCallout>
```
![Screen Shot 2020-10-15 at 3 49 04 PM](https://user-images.githubusercontent.com/17131846/96184384-0a2aef00-0efe-11eb-8af0-5a48c732fe98.png)

```hbs
<EuiCallout 
  @title="This is a Callout without block or Icon!!"
  @heading="h3"
/>
```
![Screen Shot 2020-10-15 at 3 50 57 PM](https://user-images.githubusercontent.com/17131846/96184525-38103380-0efe-11eb-88e5-7a40357391e9.png)
