### PR TITLE
fix: nested accordions not hiding child content properly

### DIFF
--- a/packages/core/addon/components/eui-accordion/index.hbs
+++ b/packages/core/addon/components/eui-accordion/index.hbs
@@ -69,7 +69,7 @@
       </button>
     {{/if}}
   </div>
-  <div class="euiAccordion__childWrapper" id={{@id}}>
+  <div class="euiAccordion__childWrapper" style={{this.childContentStyle}} id={{@id}}>
     <div
       class={{class-names
         (if this.isLoading " euiAccordion__children-isLoading")

--- a/packages/core/addon/components/eui-accordion/index.ts
+++ b/packages/core/addon/components/eui-accordion/index.ts
@@ -4,6 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { uniqueId } from '../../helpers/unique-id';
 import { argOrDefaultDecorator as argOrDefault } from '../../helpers/arg-or-default';
 import { paddingMapping } from '../../utils/css-mappings/eui-accordion';
+import { htmlSafe } from '@ember/template';
 
 type EuiAccordionPaddingSize = keyof typeof paddingMapping;
 
@@ -70,11 +71,15 @@ export default class EuiAccordionAccordionComponent extends Component<AccordionA
   constructor(owner: unknown, args: AccordionArgs) {
     super(owner, args);
 
-    this._opened = this.args.forceState ? this.args.forceState === 'open' : this.args.initialIsOpen;
+    this._opened = this.args.forceState
+      ? this.args.forceState === 'open'
+      : this.args.initialIsOpen;
   }
 
   get isOpen(): boolean {
-    return this.args.forceState ? this.args.forceState === 'open' : this._opened;
+    return this.args.forceState
+      ? this.args.forceState === 'open'
+      : this._opened;
   }
 
   get hasIconButton(): boolean | undefined {
@@ -101,10 +106,15 @@ export default class EuiAccordionAccordionComponent extends Component<AccordionA
     ].join(' ');
   }
 
+  get childContentStyle(): string | ReturnType<typeof htmlSafe> {
+    return this.isOpen ? '' : htmlSafe(`height: 0px;`);
+  }
+
   @action
   onToggle(): void {
     if (this.args.forceState) {
-      this.args.onToggle && this.args.onToggle(this.args.forceState === 'open' ? false : true);
+      this.args.onToggle &&
+        this.args.onToggle(this.args.forceState === 'open' ? false : true);
     } else {
       this._opened = !this._opened;
       this.args.onToggle && this.args.onToggle(this._opened);

--- a/packages/core/docs/layout/accordion-demo/demo1.md
+++ b/packages/core/docs/layout/accordion-demo/demo1.md
@@ -76,6 +76,32 @@ The accordion is
     My content
   </:content>
 </EuiAccordion>
+
+<h1>Nested accordions</h1>
+<EuiAccordion>
+  <:buttonContent>
+    Parent accordion
+  </:buttonContent>
+  <:content>
+    Parent content
+    <EuiAccordion>
+      <:buttonContent>
+        Child accordion
+      </:buttonContent>
+      <:content>
+        Child content
+        <EuiAccordion>
+          <:buttonContent>
+            Grandchild accordion
+          </:buttonContent>
+          <:content>
+            Grandchild content
+          </:content>
+        </EuiAccordion>
+      </:content>
+    </EuiAccordion>
+  </:content>
+</EuiAccordion>
 ```
 
 ```js component


### PR DESCRIPTION
When  nested accordions were used if the top accordion was opened the rest of the nested accordions would show their content even if they were closed.