### PR TITLE
fix: typo in index.js

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -15,7 +15,7 @@ module.exports = {
     }
   },
 
-  inDevelopingAddon() {
+  isDevelopingAddon() {
     return true;
   },
 


### PR DESCRIPTION
The `isDevelopingAddon` function had a typo.