### PR TITLE
fix: close on option create. disable clear when input is disabled.

### DIFF
--- a/packages/core/addon/components/eui-combo-box/index.hbs
+++ b/packages/core/addon/components/eui-combo-box/index.hbs
@@ -27,7 +27,7 @@
     onCreateOption=(if
       @onCreateOption (pipe this.onCreateOption @onCreateOption)
     )
-    isClearable=@isClearable
+    isClearable=(and @isClearable (not @disabled))
   }}
   @matcher={{@matcher}}
   @initiallyOpen={{@initiallyOpen}}
@@ -51,7 +51,7 @@
   @triggerRole={{@triggerRole}}
   @title={{@title}}
   @triggerId={{@triggerId}}
-  @allowClear={{@isClearable}}
+  @allowClear={{and @isClearable (not @disabled)}}
   @loadingMessage={{@loadingMessage}}
   @selectedItemComponent={{@selectedItemComponent}}
   @beforeOptionsComponent={{if

--- a/packages/core/addon/components/eui-combo-box/index.ts
+++ b/packages/core/addon/components/eui-combo-box/index.ts
@@ -66,6 +66,7 @@ export default class EuiComboBoxComponent extends Component<EuiComboBoxArgs> {
   onCreateOption() {
     let search = this.select.searchText;
     this.select.actions.search('');
+    this.select.actions.close();
     return search;
   }
 


### PR DESCRIPTION
`EuiComboBox` is `clearable` even if the input is `disabled`.
When creating a new option the dropdown list would stay open and wouldn't trigger `blur` events.