### PR TITLE
fix: onChange not triggered when onCreateOption

### DIFF
--- a/packages/core/addon/components/eui-combo-box/index.ts
+++ b/packages/core/addon/components/eui-combo-box/index.ts
@@ -66,6 +66,7 @@ export default class EuiComboBoxComponent extends Component<EuiComboBoxArgs> {
   onCreateOption() {
     let search = this.select.searchText;
     this.select.actions.search('');
+    this.select.actions.select(search);
     this.select.actions.close();
     return search;
   }


### PR DESCRIPTION
`onChange` is not being called in `EuiComboBox` when `onCreateOption` is triggered.