### PR TITLE
feat: add item props to description and field flex items in EuiDescribedFormGroup

### DIFF
--- a/packages/core/addon/components/eui-described-form-group/index.hbs
+++ b/packages/core/addon/components/eui-described-form-group/index.hbs
@@ -7,7 +7,7 @@
   ...attributes
 >
   <EuiFlexGroup @gutterSize={{arg-or-default @gutterSize "l"}}>
-    <EuiFlexItem>
+    <EuiFlexItem @grow={{@descriptionFlexItemProps.grow}}>
       <EuiTitle class="euiDescribedFormGroup__title" @size={{@titleSize}}>
         {{yield to="title"}}
       </EuiTitle>
@@ -25,6 +25,7 @@
         componentName="EuiDescribedFormGroup"
         paddingSize=(arg-or-default @titleSize "xs")
       }}
+      @grow={{@fieldFlexItemProps.grow}}
     >
       {{yield}}
     </EuiFlexItem>


### PR DESCRIPTION
Add `@fieldFlexItemProps` and `@descriptionFlexItemProps` args to `EuiDescribedFormGroup` to allow passing arguments to the `description` and `field` components.