### PR TITLE
feat: allow passing classes to checkbox label

### DIFF
--- a/packages/core/addon/components/eui-checkbox/index.hbs
+++ b/packages/core/addon/components/eui-checkbox/index.hbs
@@ -24,7 +24,10 @@
       />
       <div class="euiCheckbox__square"></div>
       {{#if (or hasLabelBlock @label)}}
-        <label class="euiCheckbox__label" for={{id}}>
+        <label
+          class={{class-names "euiCheckbox__label" @labelProps.className}}
+          for={{id}}
+        >
           {{#if hasLabelBlock}}
             {{yield to="label"}}
           {{else}}


### PR DESCRIPTION
Add `@labelProps` to `EuiCheckbox` to allow passing attributes to the `label` element.

It only supports `className` right now, any other attributes will have to be added as needed.