### PR TITLE
feat: allow passing classes to radio label

### DIFF
--- a/packages/core/addon/components/eui-radio/index.hbs
+++ b/packages/core/addon/components/eui-radio/index.hbs
@@ -22,7 +22,10 @@
       />
       <div class="euiRadio__circle"></div>
       {{#if (or hasLabelBlock @label)}}
-        <label class="euiRadio__label" for={{id}}>
+        <label
+          class={{class-names "euiRadio__label" @labelProps.className}}
+          for={{id}}
+        >
           {{#if hasLabelBlock}}
             {{yield to="label"}}
           {{else}}


### PR DESCRIPTION
Add `@labelProps` to `EuiRadio` to allow passing attributes to the `label` element.

It only supports `className` right now, any other attributes will have to be added as needed.