### PR TITLE
fix: add placeholder prop to search field

### DIFF
--- a/packages/core/addon/components/eui-field-search/index.hbs
+++ b/packages/core/addon/components/eui-field-search/index.hbs
@@ -43,6 +43,7 @@
           value={{this.value}}
           disabled={{@disabled}}
           type="text"
+          placeholder={{@placeholder}}
           ...attributes
           {{on "keyup" (fn this.onKeyUp this.incremental @onSearch)}}
           {{on "search" this.setValue}}


### PR DESCRIPTION
Add missing attribute `placeholder` to `EuiFieldSearch`