### PR TITLE
fix: add placeholder to text field

### DIFF
--- a/packages/core/addon/components/eui-field-text/index.hbs
+++ b/packages/core/addon/components/eui-field-text/index.hbs
@@ -20,6 +20,7 @@
         class={{classes}}
         disabled={{@disabled}}
         type="text"
+        placeholder={{@placeholder}}
         ...attributes
         {{validatable-control @isInvalid}}
         {{did-insert (optional @inputRef)}}
@@ -45,6 +46,7 @@
             class={{classes}}
             disabled={{@disabled}}
             type="text"
+            placeholder={{@placeholder}}
             ...attributes
             {{validatable-control @isInvalid}}
           />


### PR DESCRIPTION
Add `placeholder` argument to `EuiFieldText`