### PR TITLE
fix: add styles to core

### DIFF
--- a/packages/core/addon/styles/ember-eui.css
+++ b/packages/core/addon/styles/ember-eui.css
@@ -21,3 +21,7 @@
 .ember-basic-dropdown-content {
   z-index: 99999
 }
+
+.euiBadge__iconButton svg {
+  pointer-events: none;
+}

--- a/site/app/styles/app.css
+++ b/site/app/styles/app.css
@@ -16,9 +16,6 @@ body.euiBody--headerIsFixed {
   color: white;
 }
 
-.euiBadge__iconButton svg {
-  pointer-events: none;
-}
 .euiPanel--restrictWidth-custom {
   margin-left: auto;
   margin-right: auto;
@@ -143,7 +140,7 @@ p>p:last-child{
 }
 
 a span.icon-link:hover {
-  
+
 }
 div.docfy-demo__description__header > h2 > a > span {
   /* content: '#'; */


### PR DESCRIPTION
Fixes combobox badges clear button not deleting the badge.
Move the CSS to core instead of the site styles.