### PR TITLE
fix: quick select not setting selected value

### DIFF
--- a/packages/core/addon/components/eui-field-number/index.hbs
+++ b/packages/core/addon/components/eui-field-number/index.hbs
@@ -46,9 +46,11 @@
             id={{inputId}}
             class={{classes}}
             value={{@value}}
+            min={{@min}}
+            max={{@max}}
+            disabled={{@disabled}}
             step={{@step}}
             type="number"
-            disabled={{@disabled}}
             ...attributes
             {{validatable-control @isInvalid}}
           />

--- a/packages/core/addon/components/eui-super-date-picker/eui-quick-select-popover/eui-quick-select.hbs
+++ b/packages/core/addon/components/eui-super-date-picker/eui-quick-select-popover/eui-quick-select.hbs
@@ -106,7 +106,7 @@
               aria-describedby={{concat this.timeSelectionId " " legendId}}
               aria-label={{valueLabel}}
               @value={{this.timeValue}}
-              @onChange={{this.onTimeValueChange}}
+              {{on "input" (pick "target.value" (set this "timeValue"))}}
             />
           </Token>
         </EuiI18n>


### PR DESCRIPTION
Fixes `EuiQuickSelect` not updating the `timeValue` on change.
Adds missing attributes to `EuiFieldNumber` when `@controlOnly` is `false`.