### PR TITLE
fix: tooltip not repositioning when scrolling

### DIFF
--- a/packages/core/addon/components/eui-tool-tip-popover/index.ts
+++ b/packages/core/addon/components/eui-tool-tip-popover/index.ts
@@ -16,12 +16,14 @@ export default class EuiTooltipPopover extends Component<EuiTooltipPopoverArgs> 
     super(owner, args);
     document.body.classList.add('euiBody-hasPortalContent');
     window.addEventListener('resize', this.updateDimensions);
+    window.addEventListener('scroll', this.updateDimensions, true);
   }
 
   willDestroy(): void {
     super.willDestroy();
     document.body.classList.remove('euiBody-hasPortalContent');
     window.removeEventListener('resize', this.updateDimensions);
+    window.removeEventListener('scroll', this.updateDimensions, true);
   }
 
   @action


### PR DESCRIPTION
When scrolling with a tooltip opened, the tooltip stays in the same position where it was opened.
Most notable on mobile devices.