### PR TITLE
fix: recalculate validity when child is unregistered

### DIFF
--- a/packages/validated-form/addon/components/validated-form/index.js
+++ b/packages/validated-form/addon/components/validated-form/index.js
@@ -68,6 +68,9 @@ export default class ValidatedForm extends Component {
   unregister(child) {
     if (!this.isDestroyed) {
       schedule('afterRender', this, this.removeChild, child);
+      // When adding a child the validation gets calculated on a `did-insert` modifier
+      // for removal there's no modifier so it gets called here
+      schedule('afterRender', this, this.triggerValidityChange);
     }
   }
 


### PR DESCRIPTION
Fix recalculating validity on `ValidatedForm` when a child gets `unregistered`